### PR TITLE
Initial Next.js monorepo scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# BadmintonClub
+# Badminton Club
+
+A monorepo containing a mobile-first Next.js application for managing badminton club members and matches.
+
+## Project Structure
+
+- `apps/web` - Next.js frontend + API routes
+- `packages/db` - Mongoose models and connection helpers
+
+## Setup
+
+1. Install Node.js dependencies (requires internet access):
+   ```sh
+   npm install
+   ```
+2. Configure environment variables in `apps/web/.env.local`.
+3. Run the development server:
+   ```sh
+   npm run dev --workspace=web
+   ```
+
+This project is designed to be deployed to Vercel.

--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -1,0 +1,2 @@
+MONGODB_URI=mongodb://localhost:27017/badminton
+NEXTAUTH_SECRET=secret

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone'
+};
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "mongoose": "^7.0.0",
+    "next-auth": "^4.24.0",
+    "tailwindcss": "^3.3.0"
+  }
+}

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { connect } from '../../../../../../packages/db/src';
+import { User } from '../../../../../../packages/db/src/models/User';
+
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+  await connect(process.env.MONGODB_URI || '');
+  const user = await User.findOne({ email, password });
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  }
+  // TODO: set session cookie
+  return NextResponse.json({ message: 'Logged in' });
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  // TODO: clear session cookie
+  return NextResponse.json({ message: 'Logged out' });
+}

--- a/apps/web/src/app/api/matches/route.ts
+++ b/apps/web/src/app/api/matches/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { connect } from '../../../../../packages/db/src';
+import { Match } from '../../../../../packages/db/src/models/Match';
+import { User } from '../../../../../packages/db/src/models/User';
+
+export async function POST(request: Request) {
+  const { playerIds, scores, season, createdBy } = await request.json();
+  await connect(process.env.MONGODB_URI || '');
+  const user = await User.findById(createdBy);
+  if (!user || (user.role !== 'admin' && user.role !== 'sub-admin')) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+  const match = await Match.create({ players: playerIds, scores, season, createdBy });
+  // simple battle score algorithm: add total points to players
+  for (let i = 0; i < playerIds.length; i++) {
+    await User.findByIdAndUpdate(playerIds[i], { $inc: { battleScore: scores[i] } });
+  }
+  return NextResponse.json(match);
+}

--- a/apps/web/src/app/api/users/route.ts
+++ b/apps/web/src/app/api/users/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { connect } from '../../../../../packages/db/src';
+import { User } from '../../../../../packages/db/src/models/User';
+
+export async function POST(request: Request) {
+  const { email, name, password } = await request.json();
+  await connect(process.env.MONGODB_URI || '');
+  const user = await User.create({ email, name, password });
+  return NextResponse.json(user);
+}
+
+export async function GET() {
+  await connect(process.env.MONGODB_URI || '');
+  const users = await User.find();
+  return NextResponse.json(users);
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import '../styles/globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100">{children}</body>
+    </html>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: implement login logic
+  };
+
+  return (
+    <main className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-semibold text-center">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="w-full border p-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="w-full border p-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-500 text-white p-2 rounded" type="submit">
+          Login
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/app/logout/page.tsx
+++ b/apps/web/src/app/logout/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+export default function Logout() {
+  return (
+    <main className="flex items-center justify-center min-h-screen p-4">
+      <p>Logging out...</p>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center justify-center min-h-screen p-4">
+      <h1 className="text-3xl font-bold mb-4">Badminton Club</h1>
+      <p className="mb-2">Welcome to the club management app.</p>
+    </main>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-gray-900;
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "badminton-club",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "next dev -w apps/web",
+    "build": "next build apps/web",
+    "start": "next start apps/web"
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "db",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "private": true,
+  "dependencies": {
+    "mongoose": "^7.0.0"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,6 @@
+import mongoose from 'mongoose';
+
+export async function connect(uri: string) {
+  if (mongoose.connection.readyState === 1) return;
+  await mongoose.connect(uri);
+}

--- a/packages/db/src/models/Match.ts
+++ b/packages/db/src/models/Match.ts
@@ -1,0 +1,17 @@
+import { Schema, model, models, Types } from 'mongoose';
+
+export interface IMatch {
+  players: Types.ObjectId[];
+  scores: number[];
+  season: string;
+  createdBy: Types.ObjectId;
+}
+
+const MatchSchema = new Schema<IMatch>({
+  players: [{ type: Schema.Types.ObjectId, ref: 'User', required: true }],
+  scores: [{ type: Number, required: true }],
+  season: { type: String, required: true },
+  createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+});
+
+export const Match = models.Match || model<IMatch>('Match', MatchSchema);

--- a/packages/db/src/models/User.ts
+++ b/packages/db/src/models/User.ts
@@ -1,0 +1,19 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface IUser {
+  email: string;
+  name: string;
+  password: string;
+  role: 'admin' | 'sub-admin' | 'member';
+  battleScore: number;
+}
+
+const UserSchema = new Schema<IUser>({
+  email: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['admin', 'sub-admin', 'member'], default: 'member' },
+  battleScore: { type: Number, default: 0 },
+});
+
+export const User = models.User || model<IUser>('User', UserSchema);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "CommonJS",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project structure with monorepo workspaces
- add Tailwind CSS styles and layout
- implement mongoose models for users and matches
- add API routes for auth, users and matches
- document setup steps in README

## Testing
- `npm install --ignore-scripts` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cfc8525688322be33dcbbe83c1865